### PR TITLE
Adding newest rest endpoint, rest.zuora.com,  but retaining backwards compatibility

### DIFF
--- a/lib/zuora/rest.rb
+++ b/lib/zuora/rest.rb
@@ -3,6 +3,9 @@ module Zuora
   module Rest
     API_URL = 'https://api.zuora.com/rest/v1/'.freeze
     SANDBOX_URL = 'https://apisandbox-api.zuora.com/rest/v1/'.freeze
+    # Newest endpoints for REST API calls
+    BETA_API_URL = 'https://rest.zuora.com/v1/'.freeze
+    BETA_SANDBOX_URL = 'https://rest.apisandbox.zuora.com/v1/'.freeze
 
     # Unable to connect. Check username / password
     ConnectionError = Class.new Errors::GenericError
@@ -20,3 +23,4 @@ module Zuora
 end
 
 require_relative 'rest/client'
+require_relative 'rest/bulk_client'

--- a/lib/zuora/version.rb
+++ b/lib/zuora/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Zuora
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
also pr'd at https://github.com/contactually/zuora-ruby/pulls